### PR TITLE
Handle failing to retrieve vtt files

### DIFF
--- a/src/js/plugins/preview-thumbnails.js
+++ b/src/js/plugins/preview-thumbnails.js
@@ -174,8 +174,12 @@ class PreviewThumbnails {
     if (src.startsWith('WEBVTT')) {
       await this.getThumbnail(src);
     } else {
-      const response = await fetch(src);
-      await this.getThumbnail(response, src);
+      try {
+        const response = await fetch(src);
+        await this.getThumbnail(response, src);
+      } catch {
+        this.player.debug.warn("Error retrieving VTT File")
+      }
     }
   }
 


### PR DESCRIPTION
### Link to related issue (if applicable)

### Summary of proposed changes

### Checklist
- [ ] Use `develop` as the base branch
- [ ] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
